### PR TITLE
chore: sweep onto pipelex 0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- **Swept onto `pipelex` 0.41.0** (`pipelex[...]==0.39.0` → `==0.41.0`, crossing two release cycles). Despite 0.41.0 being the largest breaking core release of the year, the blast radius here is small — cocode drives pipelex through its public run surface rather than its internals, so only two addresses moved: `pipelex.hub` was deleted with no shim (split into `pipelex.runtime_hub` / `pipelex.interpreter_hub` by owning layer, and `get_required_concept` is interpreter-layer), and `PipeRunMode` moved from `pipelex.pipe_run.pipe_run_mode` to `pipelex.system.pipe_run_mode`. Nothing in the parser move, the Pipe-machinery move, the `pipelex.providers` vendor rename, or the `Concept`-becomes-pure-data change reaches this repo.
 - **CI:** Added Python 3.14 to the lint and test matrices, so every version advertised in the package classifiers is now actually tested.
 - **Core:** Import `StrEnum` from the stdlib `enum` module instead of the `pipelex.types` re-export, which upstream deleted along with its own 3.10 support.
 - **Tooling:** Point mypy at local paths (`files`) rather than module names (`packages`), so an editable `pipelex` checkout on the import path no longer drags that repo's test suite into our type check.

--- a/cocode/cli/analyze/analyze_cli.py
+++ b/cocode/cli/analyze/analyze_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Annotated, List, Optional
 
 import typer
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.tools.misc.file_utils import load_text_from_path
 
 from cocode.common import get_output_dir, validate_repo_path

--- a/cocode/cli/changelog/changelog_cli.py
+++ b/cocode/cli/changelog/changelog_cli.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Annotated, List, Optional
 
 import typer
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.system.pipe_run_mode import PipeRunMode
 
 from cocode.common import get_output_dir, validate_repo_path
 from cocode.swe.swe_cmd import swe_from_repo_diff

--- a/cocode/cli/features/features_cli.py
+++ b/cocode/cli/features/features_cli.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Annotated, Optional
 
 import typer
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.system.pipe_run_mode import PipeRunMode
 
 from cocode.common import PipeCode, get_output_dir
 from cocode.swe.swe_cmd import swe_from_file

--- a/cocode/cli/repo/repo_cli.py
+++ b/cocode/cli/repo/repo_cli.py
@@ -6,7 +6,7 @@ import asyncio
 from typing import Annotated, List, Optional
 
 import typer
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.system.pipe_run_mode import PipeRunMode
 
 from cocode.common import PipeCode, get_output_dir, validate_repo_path
 from cocode.repox.models import OutputStyle

--- a/cocode/swe/swe_cmd.py
+++ b/cocode/swe/swe_cmd.py
@@ -8,10 +8,10 @@ from pipelex.core.memory.working_memory_factory import WorkingMemoryFactory
 from pipelex.core.pipes.pipe_output import PipeOutput
 from pipelex.core.stuffs.list_content import ListContent
 from pipelex.core.stuffs.stuff_factory import StuffFactory
-from pipelex.hub import get_required_concept
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
+from pipelex.interpreter_hub import get_required_concept
 from pipelex.pipeline.runner import PipelexMTHDSProtocol
 from pipelex.reporting.cost_report_renderer import render_cost_report_for_output
+from pipelex.system.pipe_run_mode import PipeRunMode
 from pipelex.tools.misc.file_utils import ensure_path, failable_load_text_from_path, load_text_from_path, save_text_to_path
 
 from cocode.pipelines.doc_proofread.doc_proofread_models import DocumentationFile, DocumentationInconsistency, RepositoryMap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "pipelex[anthropic,google,google-genai,bedrock]==0.39.0",
+  "pipelex[anthropic,google,google-genai,bedrock]==0.41.0",
   "PyGithub==2.4.0",
 ]
 

--- a/tests/integration/test_basic.py
+++ b/tests/integration/test_basic.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from pipelex.hub import get_required_concept
+from pipelex.interpreter_hub import get_required_concept
 from pipelex.pipeline.bundle_validator import BundleValidator
 
 

--- a/tests/integration/test_hello_world.py
+++ b/tests/integration/test_hello_world.py
@@ -1,6 +1,6 @@
 import pytest
-from pipelex.pipe_run.pipe_run_mode import PipeRunMode
 from pipelex.pipeline.runner import PipelexMTHDSProtocol
+from pipelex.system.pipe_run_mode import PipeRunMode
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
     { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["anthropic", "google", "google-genai", "bedrock"], specifier = "==0.39.0" },
+    { name = "pipelex", extras = ["anthropic", "google", "google-genai", "bedrock"], specifier = "==0.41.0" },
     { name = "pygithub", specifier = "==2.4.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -1789,7 +1789,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.39.0"
+version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1831,9 +1831,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/b4/77f21fa019459e7fe5aec994d3d3f862453fc49951a5c0e3d7309719afb0/pipelex-0.39.0.tar.gz", hash = "sha256:e6ef93b6c39aa9b76913619e2aeb32a9b03bfa7b87993988be5032c17b83ab35", size = 1138301, upload-time = "2026-07-14T20:46:32.158Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/4c/726d47759776d9925ac6db7c9e067b5d049ba78d4c501b54d2fe2d21e395/pipelex-0.41.0.tar.gz", hash = "sha256:8171379be542b77e85b2db01cf323ba3916dc781f8daa89e81d1afe4d3a35ff0", size = 1190597, upload-time = "2026-07-30T12:18:25.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/f2/6d51588a30ffe4eace7957b1936d254b80655d889e393a220aeecd7edaa4/pipelex-0.39.0-py3-none-any.whl", hash = "sha256:d8c975cc57d55c4538c270129742a333b2dfac19987c8448f62359cc2f21a3ae", size = 1597845, upload-time = "2026-07-14T20:46:30.056Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a6b88823b0bfdae5d7bde36640cba4678f5a8d4b6300a49da2f4ad1dae9b/pipelex-0.41.0-py3-none-any.whl", hash = "sha256:ea12d1dcfec29d2b9ce64bb66eea8d4dd9fa506797ce7942535cde4e4bdc0986", size = 1665487, upload-time = "2026-07-30T12:18:23.894Z" },
 ]
 
 [package.optional-dependencies]
@@ -1856,17 +1856,17 @@ google-genai = [
 
 [[package]]
 name = "pipelex-tools-py"
-version = "0.1.1"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/7a/475d5314cf2c8a402ff646ebf435ccc9d51b9d4e3c52eb063b37130e6ee5/pipelex_tools_py-0.1.1.tar.gz", hash = "sha256:ec1f5e30fe666417f210a5bb1013394cef8b0c246d070037d78cf8dfcd086603", size = 114697, upload-time = "2026-06-29T10:23:00.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/b7/2931b7a798a4537eb36dfb895523016833a46f4fbeea39eb2779aa7a90ad/pipelex_tools_py-0.1.4.tar.gz", hash = "sha256:5b4c64bb5d5b43b032c59a09f946d98242f7924ec9ac9763ef59a17df207a3ae", size = 123277, upload-time = "2026-07-21T20:51:56.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/51/701114de4b1744dbddf37ec172ab97649177d6c7c761d75689a4b1ea6788/pipelex_tools_py-0.1.1-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:69e930881da8787259cf3040eb33b669dfb4bd4ed13c8a68f082ee284f4fa3a7", size = 2490500, upload-time = "2026-06-29T10:22:48.96Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/4f/3f28ffe46d8a31760841f29a773519794b86c3e4a1d4eec70c9b74f97282/pipelex_tools_py-0.1.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:fe07dbf840deace1fa8bebe8154fef0abb4284177aae89961437edf9bddf3257", size = 2388577, upload-time = "2026-06-29T10:22:50.771Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/79/6d235117695c803946ae0fdcb5ad9410c11ed70f7182bf7a01460bf4d410/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:29b818d6af5af6510bf25505acbe7d3cdca309f1443cd95299c61b0b7fd0e180", size = 2717460, upload-time = "2026-06-29T10:22:52.446Z" },
-    { url = "https://files.pythonhosted.org/packages/43/aa/31f70c2ef5b7417d0b46c3b1079f797d3d42a2fc60ceaf176a8a9d52938f/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:902b69127df66a91f80d3b3158217ff29aa40c2ad86917b46de7e9640a6f81ab", size = 2505388, upload-time = "2026-06-29T10:22:53.902Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/4f/53f3e3e10391d3035bbc84966a80439277b04a9efc8cab09e890871a3cfe/pipelex_tools_py-0.1.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f89c17a9c58161ff0ff515bc7054bfc58710c9edec3d4dfc842d07966f239ba", size = 2629996, upload-time = "2026-06-29T10:22:55.713Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/72/4a68e0b3f3c758c0808a888db40299d46af1f79b23aa0c3fcc442f3a68de/pipelex_tools_py-0.1.1-cp38-abi3-win32.whl", hash = "sha256:b26e93fd975682b7dc15d0d300ddb540650cfdf9dff917a6e4880cc1283e83c8", size = 2396611, upload-time = "2026-06-29T10:22:57.173Z" },
-    { url = "https://files.pythonhosted.org/packages/98/16/aa4ad4790c29d2f7d0a9160e3fe2faf1b8be12d9dde081f989654038fc63/pipelex_tools_py-0.1.1-cp38-abi3-win_amd64.whl", hash = "sha256:a925bdc2e0ee00dde3adc9fe360e227f2968376b2ed0bbe4e14bb82014d9ac7e", size = 2633419, upload-time = "2026-06-29T10:22:58.875Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1f/ec6f5e1c9f05c0265da6d1d9f8929a2ecc3e3fc81fc0dd8e848b0e7193fd/pipelex_tools_py-0.1.4-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9c28fb9b0e60f64562946c517db02b1dfec28dd2052396e4b245c765ec351b19", size = 2489364, upload-time = "2026-07-21T20:51:43.563Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ba/90eefe4468ad230ccdaa2fed87713c9b0a7f28d150db1cd79ffc1f177098/pipelex_tools_py-0.1.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:47cb36625191b8261a064a2db9acd5fa8f1d58a8066863443ebee7ec1df0f593", size = 2392390, upload-time = "2026-07-21T20:51:45.667Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ea/6bae0789b557afa7d3e8029a941889ffdd57fe1a757e8cedd96cef41b203/pipelex_tools_py-0.1.4-cp38-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5a8fe923e1f4930161c4b31ae6f494dfd590d60fd334a04570b362f8fe56a5b6", size = 2715843, upload-time = "2026-07-21T20:51:47.587Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3d/d4040c4b9b597f85bcd963f1e15bdb0eba799e2d1a3e0d5518d01f183eac/pipelex_tools_py-0.1.4-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f324232bb8cd20725b35d8e96db30e4e4707bae525005ca1c3e829f3983056", size = 2511975, upload-time = "2026-07-21T20:51:49.421Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/85/ee8395199d977aa82b6dfaf6343a719407de1b25e696f6016ab120a65d94/pipelex_tools_py-0.1.4-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7329f6657b76828b6d370d2385595e85e525e22fcff356171ddb9cbc4b27fe18", size = 2632376, upload-time = "2026-07-21T20:51:51.375Z" },
+    { url = "https://files.pythonhosted.org/packages/17/18/2563a4b695b1bfbaa481dc736d41d3f48689ed75830797d01a84e09842c6/pipelex_tools_py-0.1.4-cp38-abi3-win32.whl", hash = "sha256:1a624bb5ef694da6af7fc8177b5123c27a9dd0133e8213cee08d1f87347608b8", size = 2403574, upload-time = "2026-07-21T20:51:53.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a9/a6ce253ff98dcff497cee9b0a7b09e85ef8292e95e13f33b32abcf8c8bbd/pipelex_tools_py-0.1.4-cp38-abi3-win_amd64.whl", hash = "sha256:c548933580edb308fe3d6c2f1c43116ab0731445df0aa7e77b107a0072ee8584", size = 2641676, upload-time = "2026-07-21T20:51:55.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of the workspace-wide sweep onto `pipelex` 0.41.0.

**Stacked on `chore/drop-python-3.10-support`** — this branch was cut from it, so it is the PR base. Merge the parent first; this one then retargets to `dev` on its own.

Bumps `pipelex[...]==0.39.0` → `==0.41.0`, crossing two release cycles.

## Small blast radius, and that is worth recording

Despite 0.41.0 being the largest breaking core release of the year, cocode drives `pipelex` through its **public run surface** rather than reaching into internals — so the parser move out of `core/`, the Pipe-machinery move, the `pipelex.providers` vendor rename and the Concept-becomes-pure-data change all miss this repo entirely.

Two addresses moved: `pipelex.hub` is deleted with no shim and split by owning layer, so `get_required_concept` now comes from `pipelex.interpreter_hub`; and `PipeRunMode` moved to `pipelex.system.pipe_run_mode`.

`agent-check` and `agent-test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XjPhRAkJnL9YoSkR2GEoD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade to `pipelex` 0.41.0 and update import paths for breaking changes. CLI commands and tests remain green.

- **Dependencies**
  - Bump `pipelex[anthropic,google,google-genai,bedrock]` from `==0.39.0` to `==0.41.0`.
  - Lockfile refresh updates `pipelex-tools-py` to `0.1.4`.

- **Refactors**
  - Repoint `get_required_concept` to `pipelex.interpreter_hub`.
  - Import `PipeRunMode` from `pipelex.system.pipe_run_mode`.

<sup>Written for commit bf49bec2e6fa31e92a5993d5534f2ec4cc01339d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/cocode/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

