### PR TITLE
Bump pipelex to 0.45.0 and qualify cross-domain pipe reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **Dependencies:** Bumped `pipelex` to `0.45.0` (from `0.42.0`).
+
+### Fixed
+- **Pipelines:** The `write_changelog_enhanced` sequence in `swe_diff/changelog_enhanced.mthds` referenced `format_changelog_as_markdown` without its domain, but that pipe is declared in the `changelog` domain. `pipelex` 0.45.0 resolves an unqualified pipe reference strictly inside the referencing pipe's own domain, so this became a hard startup failure for every `cocode` command. The reference is now written out as `changelog.format_changelog_as_markdown`.
+
 ## [v0.9.0] - 2026-08-01
 
 ### Changed

--- a/cocode/pipelines/swe_diff/changelog_enhanced.mthds
+++ b/cocode/pipelines/swe_diff/changelog_enhanced.mthds
@@ -14,7 +14,7 @@ output = "changelog.MarkdownChangelog"
 steps = [
   { pipe = "draft_changelog_from_git_diff", result = "draft_changelog" },
   { pipe = "polish_changelog", result = "structured_changelog" },
-  { pipe = "format_changelog_as_markdown", result = "markdown_changelog" },
+  { pipe = "changelog.format_changelog_as_markdown", result = "markdown_changelog" },
 ]
 
 [pipe.draft_changelog_from_git_diff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 
 dependencies = [
-  "pipelex[anthropic,google,google-genai,bedrock]==0.42.0",
+  "pipelex[anthropic,google,google-genai,bedrock]==0.45.0",
   "PyGithub==2.4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "==9.6.14" },
     { name = "mkdocs-meta-manager", marker = "extra == 'docs'", specifier = "==1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.2" },
-    { name = "pipelex", extras = ["anthropic", "google", "google-genai", "bedrock"], specifier = "==0.42.0" },
+    { name = "pipelex", extras = ["anthropic", "google", "google-genai", "bedrock"], specifier = "==0.45.0" },
     { name = "pygithub", specifier = "==2.4.0" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.411" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
@@ -1789,7 +1789,7 @@ wheels = [
 
 [[package]]
 name = "pipelex"
-version = "0.42.0"
+version = "0.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -1831,9 +1831,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/5e/ccf07098883f1550e3e8af18ede0d2a6dcd065e4b81b829eb6776949a784/pipelex-0.42.0.tar.gz", hash = "sha256:531ffe69a39e772626ab144543841afe28d6bc07b1df6c4dfcf96296250a3b88", size = 1200697, upload-time = "2026-08-01T07:32:57.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/a8/9157a3f0f5362f013dbcfcffd88497a80ec8364c9f829bc0bdca0629c994/pipelex-0.45.0.tar.gz", hash = "sha256:279c0bb250edfb8aa553e368942acfe4e55a0fa6511b1dd85146b8b8d7b609b6", size = 1246259, upload-time = "2026-08-14T13:18:14.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b9/cf24f0579725a8e97aadf7b93c98240a22518767eecce4b6e7dc1f6aa40c/pipelex-0.42.0-py3-none-any.whl", hash = "sha256:cf6b352a5c75cbf5fbe24d19014135b827bb3f4eeba28299bdf604691acfb003", size = 1677825, upload-time = "2026-08-01T07:32:55.098Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3a/79c86531ad5823ba3de59c238810c242025102f6309b3c35de0ee03c1425/pipelex-0.45.0-py3-none-any.whl", hash = "sha256:afca0eccf02a1ec96fc08243754b8bdf04bf0de17326357a3b79cf5c3b1d12b0", size = 1740578, upload-time = "2026-08-14T13:18:11.882Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Sweeps `cocode` onto `pipelex` 0.45.0 (from 0.42.0) and fixes the one breakage that came with it.

## The breakage

`make agent-test` aborted during Pipelex setup, before any test ran:

```
Pipe 'changelog_enhanced.write_changelog_enhanced' references
'format_changelog_as_markdown', which does not exist.
```

`format_changelog_as_markdown` is declared in the `changelog` domain (`cocode/pipelines/swe_diff/changelog.mthds`), but `changelog_enhanced.mthds` referenced it bare. `pipelex` 0.45.0 resolves an unqualified pipe reference strictly inside the referencing pipe's own domain, so what used to fall through to the sibling domain is now a hard error.

This is not test-only breakage — it would have crashed every `cocode` command at startup.

The fix is one line, matching how the same file already qualifies its cross-domain concepts (`changelog.MarkdownChangelog`):

```toml
{ pipe = "changelog.format_changelog_as_markdown", result = "markdown_changelog" },
```

## Scope

That was the only breakage from the bump. The rest of the library validated and dry-ran clean, so no `.pipelex/` deck re-sync was needed this time (unlike the 0.42.0 bump).

The version in `pyproject.toml` is deliberately untouched — the changelog entry lands under `## [Unreleased]`, since a version bump is a release action rather than a per-commit one.

## Test plan

- `make agent-test` — passes.
- `make agent-check` — ruff, pyright and mypy all clean.
- `uv lock --check` — lockfile matches the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7AZKvRabE6QfQDR9kqhGY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `pipelex` to `0.45.0` and qualifies a cross-domain pipe reference to restore startup. Previously, an unqualified `format_changelog_as_markdown` resolved across domains; 0.45.0 restricts resolution to the local domain, so the unqualified name crashed at startup; it now uses `changelog.format_changelog_as_markdown`.

- Updates dependency pins in `pyproject.toml` and `uv.lock`; no deck re-sync needed.
- Only functional change is in `swe_diff/changelog_enhanced.mthds`; pipelines start clean.
- Migration: when referencing cross-domain pipes under `pipelex` `0.45.0`, always use qualified `domain.pipe` names.

<sup>Written for commit 6ff13cbcccaa5034b3a71c650717607d952fb80d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Pipelex/cocode/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

